### PR TITLE
Add screenshot to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ You can view the application or make API calls by using the Nginx URL.
 
 You can access the database through the Adminer front-end or using a local PostgreSQL client and the following URL: `postgres://babyyoda:mysecretpassword@localhost:5432/codebuddies`.
 
+![screenshot of Adminer](https://i.imgur.com/Dtg5Yel.png)
+
 To stop the application and remove all containers, run the following.
 
 ```plain


### PR DESCRIPTION
Adds the following screenshot to the README to help folks double check how to log in to the DB front-end:

<img width="601" alt="Screen Shot 2020-02-06 at 1 48 23 AM" src="https://user-images.githubusercontent.com/4512699/73926505-94f21f00-4884-11ea-9c5a-57ae95385920.png">
