### PR TITLE
Add an instruction for creating a new superuser to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ To stop the application and remove all containers, run the following.
 docker-compose down
 ```
 
+5. Create a superuser so that you can log into http://localhost:8000/admin by running the following in your terminal: `$ docker-compose run --rm manage createsuperuser`
+
 ## Editing Code
 
 With the local environment running, you can modify the application code in your editor of choice. As you save changes, the application should reload automatically. There should be no need to restart containers to see code changes.


### PR DESCRIPTION
New contributors need to create a new superuser before they can log in to /admin and see the resources endpoint, etc.