### PR TITLE
Fix #56 run tests on all pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  test:
+
+    name: test
+    runs-on: ubuntu-latest
+          
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run application
+      run: docker-compose up -d
+    
+    - name: Test Resources
+      run: docker-compose run --rm manage test resources
+
+    - name: Test Users
+      run: docker-compose run --rm manage test users
+      if: always()
+
+    - name: Test UserAuth
+      run: docker-compose run --rm manage test userauth
+      if: always()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Django proof-of-concept for CodeBuddies V3
 
+![Test](https://github.com/billglover/django-concept/workflows/Test/badge.svg)
+
 Background: https://github.com/codebuddies/codebuddies/issues/1136
 
 The API spec all the proof-of-concepts: https://app.swaggerhub.com/apis-docs/billglover/CodeBuddies/0.0.1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Django proof-of-concept for CodeBuddies V3
 
-![Test](https://github.com/billglover/django-concept/workflows/Test/badge.svg)
+![Test](https://github.com/codebuddies/django-concept/workflows/Test/badge.svg)
 
 Background: https://github.com/codebuddies/codebuddies/issues/1136
 


### PR DESCRIPTION
Use GitHub actions to run all tests when a Pull Request gets raised.

**Note:** Tests are currently failing but these fail irrespective of this change. This change should give greater visibility to the current status of tests.